### PR TITLE
Only evaluate github stuff when running bootrun and componentTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,10 +105,10 @@ def injectGithubCredentials = {
     }
 }
 
-bootRun {
+bootRun.doFirst {
     configure injectGithubCredentials
 }
 
-componentTest {
+componentTest.doFirst {
     configure injectGithubCredentials
 }


### PR DESCRIPTION
Before: any gradle command will throw an error if the you don't have the github credentials. 

After: only requires github credentials for the tasks that need it.
